### PR TITLE
[FIX] Fix typos, refactor resources types

### DIFF
--- a/src/components/Resources/container/index.tsx
+++ b/src/components/Resources/container/index.tsx
@@ -1,20 +1,8 @@
-import { useCallback, useState } from "react";
-import type {
-  CompetitveProgrammingResource,
-  OsuResource,
-  WebDevelopmentResource,
-} from "../../../types";
+import { useCallback } from "react";
 import { CompProResources, OsuEecsResources, WebDevResources } from "../render";
+import type { ResourceMap } from "../types.ts";
 
-interface ResourcesProps {
-  resources: {
-    compPro: CompetitveProgrammingResource[];
-    webDev: WebDevelopmentResource[];
-    eecsOsu: OsuResource[];
-  };
-}
-
-export default function ResourcesContainer({ resources }: ResourcesProps) {
+export default function ResourcesContainer({ resources }: { resources: ResourceMap }) {
   const handleCardClick = useCallback((link: string) => {
     window.open(link, "_blank");
   }, []);

--- a/src/components/Resources/data.ts
+++ b/src/components/Resources/data.ts
@@ -1,6 +1,6 @@
-import { type CompetitveProgrammingResource, type OsuResource, type WebDevelopmentResource } from "../../types";
+import type { CompetitiveProgrammingResource, OsuResource, WebDevelopmentResource } from "../../types";
 
-const compProResources: CompetitveProgrammingResource[] = [
+const compProResources: CompetitiveProgrammingResource[] = [
       {
             title: "Leetcode",
             text: "Platform for practicing technical interview questions.",
@@ -158,10 +158,10 @@ const eecsOsuResources: OsuResource[] = [
       }
 ];
 
-const resouceMap = {
+const resourceMap = {
       compPro: compProResources,
       webDev: webDevResources,
       eecsOsu: eecsOsuResources,
 };
 
-export default resouceMap;
+export default resourceMap;

--- a/src/components/Resources/index.tsx
+++ b/src/components/Resources/index.tsx
@@ -1,11 +1,11 @@
 import ResourcesContainer from "./container";
-import resouceMap from "./data";
+import resourceMap from "./data";
 import "./style.css";
 
 const ResourcesGrid = () => {
   return (
     <section className="resources">
-      <ResourcesContainer resources={resouceMap} />
+      <ResourcesContainer resources={resourceMap} />
     </section>
   );
 };

--- a/src/components/Resources/render/index.tsx
+++ b/src/components/Resources/render/index.tsx
@@ -2,20 +2,16 @@ import { useAutoAnimate } from "@formkit/auto-animate/react";
 import { useState } from "react";
 import { TagFilter } from "..";
 import {
-  type CompetitveProgrammingResource,
+  type CompetitiveProgrammingResource,
   type OsuResource,
   type WebDevelopmentResource,
 } from "../../../types";
-
-interface OsuEecsResourcesProps {
-  resources: OsuResource[];
-  handleCardClick: (link: string) => void;
-}
+import type { ResourcesProps } from "../types.ts";
 
 export const OsuEecsResources = ({
   resources,
   handleCardClick,
-}: OsuEecsResourcesProps) => {
+}: ResourcesProps<OsuResource[]>) => {
   const [parent] = useAutoAnimate();
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
   const handleTagClick = (tag: string | null) => {
@@ -81,12 +77,7 @@ export const OsuEecsResources = ({
   );
 };
 
-interface ComProps {
-  resources: CompetitveProgrammingResource[];
-  handleCardClick: (link: string) => void;
-}
-
-export const CompProResources = ({ resources, handleCardClick }: ComProps) => {
+export const CompProResources = ({ resources, handleCardClick }: ResourcesProps<CompetitiveProgrammingResource[]>) => {
   const [parent] = useAutoAnimate();
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
   const handleTagClick = (tag: string | null) => {
@@ -118,7 +109,7 @@ export const CompProResources = ({ resources, handleCardClick }: ComProps) => {
               (resource.tags && resource.tags.includes(selectedTag))
           )
           .slice(0, displayLimit)
-          .map((resource: CompetitveProgrammingResource, index) => (
+          .map((resource: CompetitiveProgrammingResource, index) => (
             <div
               className="resources__card"
               key={index}
@@ -158,15 +149,10 @@ export const CompProResources = ({ resources, handleCardClick }: ComProps) => {
   );
 };
 
-interface WebDevProps {
-  resources: WebDevelopmentResource[];
-  handleCardClick: (link: string) => void;
-}
-
 export const WebDevResources = ({
   resources,
   handleCardClick,
-}: WebDevProps) => {
+}: ResourcesProps<WebDevelopmentResource[]>) => {
   const [parent] = useAutoAnimate();
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
   const handleTagClick = (tag: string | null) => {

--- a/src/components/Resources/types.ts
+++ b/src/components/Resources/types.ts
@@ -1,0 +1,10 @@
+import resourceMap from "./data.ts";
+
+export type ResourceMap = typeof resourceMap;
+
+type ResourcesCategory = ResourceMap[keyof ResourceMap]
+
+export type ResourcesProps<T extends ResourcesCategory> = {
+  resources: T;
+  handleCardClick: (link: string) => void;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export interface Resource {
       tags?: string[];
 }
 
-export interface CompetitveProgrammingResource extends Resource {
+export interface CompetitiveProgrammingResource extends Resource {
       difficulty?: string;
 }
 


### PR DESCRIPTION
Corrected several typos.

Removed the `interface ResourcesProps` since we can automatically generate this interface based on the `resourceMap` object, ensuring a single source of information. Therefore, when adding a new type of resource within `resourceMap`, there's no need to modify it in multiple places.

Eliminated duplicate types for resource components props. Instead, I created a generic `ResourcesProps<T>` that takes a specific type from union of `resourceMap` values and generates the required interface for the component based on it.