### PR TITLE
Fixed broken link on blog index page

### DIFF
--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -33,7 +33,7 @@ const recentPosts = allPosts
     <div class="right-column">
       <img
         class="logo"
-        src="acmlogo.svg"
+        src="/acmlogo.svg"
         alt="OSU ACM Logo"
         width="400"
         height="200"


### PR DESCRIPTION
The ACM logo at the top of the blog index page is a broken link (looking for `/blog/acmlogo.svg` instead of `/acmlogo.svg`), so I fixed this by adding a `/` to the start.